### PR TITLE
一致結果を一番上に表示したい

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -56,7 +56,7 @@ function lookupWord() {
     var params = 'Dic=EJdict&' +
                  'Word=' + searchWord +
                  '&Scope=HEADWORD' +
-                 '&Match=CONTAIN' +
+                 '&Match=EXACT' +
                  '&Merge=AND' +
                  '&Prof=XHTML' +
                  '&PageSize=' + MAX_RESULT_WORDS +


### PR DESCRIPTION
文字列昇順であいまい一致した 上位5件しか表示しないので
```
hot
```

などの検索結果が
```
aphotic
（深海底のように）光のない，暗やみの
bigshot
大立て者，お偉方
bloodshot
（目が）充血した，血ばしった
boilinghot
《話》（天候が）焼けつくように暑い
bowshot
《おもに文》弓の射程，矢の届く距離
```

という感じになり ```hot``` が出てこない